### PR TITLE
Fix torch numpy

### DIFF
--- a/hotxlfp/formulas/logic.py
+++ b/hotxlfp/formulas/logic.py
@@ -6,7 +6,7 @@ https://github.com/sutoiku/formula.js/blob/master/lib/logical.js
 from . import dispatcher
 from . import error
 from . import utils
-import numpy as np
+import torch
 
 
 @dispatcher.register_for('AND')
@@ -17,7 +17,7 @@ def AND(*args):
 
 @dispatcher.register_for('IF')
 def IF(test, then, otherwise):
-    return np.where(test, then, otherwise)
+    return torch.where(torch.tensor(test), torch.tensor(then), torch.tensor(otherwise))
 
 
 @dispatcher.register_for('IFERROR')

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='hotxlfp',
-    version='0.0.11-unc5',
+    version='0.0.11-unc6',
     packages=['hotxlfp', 'hotxlfp._compat', 'hotxlfp._compat.py3', 'hotxlfp.helper', 'hotxlfp.formulas', 'hotxlfp.grammarparser'],
     license='MIT',
     test_suite='tests',

--- a/tests/test_formula_parser.py
+++ b/tests/test_formula_parser.py
@@ -120,6 +120,16 @@ class TestFormulaParser(unittest.TestCase):
         result = torch.tensor(func({'a1': torch.tensor(input_vals)}))
         assert(torch.abs(result - torch.tensor(answer)) < 0.00001).all()
 
+    def test_operation_on_if(self):
+        p = Parser(debug=True)
+        func = p.parse('IF(A<0.001234,A + 1, A + 2) - A')['result']
+        input_vals = [1, 123, -432]
+        answer = [
+            2, 2, 1
+        ]
+        result = torch.tensor(func({'A': torch.tensor(input_vals)}))
+        assert(torch.abs(result - torch.tensor(answer)) < 0.00001).all()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes an issue with torch and numpy interacting, which was caused because I left an instance of `np` in when I was converting to pytorch. Error would happen if you do operations on an IF statement, because the if statement would be a np tensor while all other tensors are torch tensors.

I reproduced the same error, but with a different equation than the one used by the customer.

https://uncountable.slack.com/archives/GU31U5KFH/p1623933189050600