### PR TITLE
Fix log and trailing decimal

### DIFF
--- a/hotxlfp/formulas/mathtrig.py
+++ b/hotxlfp/formulas/mathtrig.py
@@ -178,7 +178,7 @@ def LN(number):
     number = utils.parse_number(number)
     if isinstance(number, error.XLError):
         return number
-    return torch.log(number)
+    return torch.log(torch.tensor(number))
 
 
 @dispatcher.register_for('LOG')
@@ -188,9 +188,9 @@ def LOG(number, base=None):
     if utils.any_is_error((number, base)):
         return error.VALUE
     if base is not None:
-        return torch.log(number) / torch.log(torch.tensor(base))
+        return torch.log(torch.tensor(number)) / torch.log(torch.tensor(base))
     else:
-        return torch.log(number)
+        return torch.log(torch.tensor(number))
 
 
 @dispatcher.register_for('LOG10')

--- a/hotxlfp/grammarparser/parser.py
+++ b/hotxlfp/grammarparser/parser.py
@@ -108,13 +108,17 @@ class FormulaParser(Parser):
     def p_expression_number(self, p):
         """
         expression : NUMBER
+                   | NUMBER DECIMAL
                    | NUMBER DECIMAL NUMBER
                    | NUMBER PERCENT
         """
         if len(p) == 2:
             p[0] = lambda args, p1=p[1]: to_number(p1)
         elif p[2] == '.':
-            p[0] = lambda args, p1=p[1], p3=p[3]: to_number(p1 + '.' + p3)
+            if len(p) == 4:
+                p[0] = lambda args, p1=p[1], p3=p[3]: to_number(p1 + '.' + p3)
+            else:
+                p[0] = lambda args, p1=p[1]: to_number(p1)
         elif p[2] == '^':
             p[0] = lambda args, p1=p[1], p3=p[3]: to_number(p1)**to_number(p3)
         elif p[2] == '%':

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='hotxlfp',
-    version='0.0.11-unc12',
+    version='0.0.11-unc13',
     packages=['hotxlfp', 'hotxlfp._compat', 'hotxlfp._compat.py3', 'hotxlfp.helper', 'hotxlfp.formulas', 'hotxlfp.grammarparser'],
     license='MIT',
     test_suite='tests',

--- a/tests/test_formula_parser.py
+++ b/tests/test_formula_parser.py
@@ -194,6 +194,13 @@ class TestFormulaParser(unittest.TestCase):
         result = func({"a1": 10 ** (torch.tensor([5, 23.234]))})
         assert (torch.abs(result - torch.tensor([5, 23.234])) < 0.00001).all()
 
+        _test_equation(equation="LOG(a1 / a2)", variables={"a1": [1, 2], "a2": [2, 3]}, answer=[torch.log(torch.tensor(1 / 2)), torch.log(torch.tensor(2 / 3))])
+        _test_equation(equation="LOG(123)", variables={"a1": [1]}, answer=[torch.log(torch.tensor(123))])
+
+    def test_trailing_decimal(self):
+        _test_equation(equation="1.", variables={"a1": [1]}, answer=[1])
+        _test_equation(equation="1.2", variables={"a1": [1]}, answer=[1.2])
+
 
     def test_exponent(self):
         _test_equation(equation="a1 ^ a1", variables={"a1": [1, 2]}, answer=[1, 4])

--- a/tests/test_formula_parser.py
+++ b/tests/test_formula_parser.py
@@ -199,6 +199,9 @@ class TestFormulaParser(unittest.TestCase):
 
     def test_trailing_decimal(self):
         _test_equation(equation="1.", variables={"a1": [1]}, answer=[1])
+        _test_equation(equation="1. + 1", variables={"a1": [1]}, answer=[2])
+        _test_equation(equation="SQRT(1.)", variables={"a1": [1]}, answer=[1])
+        _test_equation(equation="1 + 1.", variables={"a1": [1]}, answer=[2])
         _test_equation(equation="1.2", variables={"a1": [1]}, answer=[1.2])
 
 


### PR DESCRIPTION
- Fixes issue if you pass a constant into log, like `LOG(123)`. 
- Fixes issue if you have a trailing decimal, like `1.`