### PR TITLE
Fix leading decimal

### DIFF
--- a/hotxlfp/grammarparser/parser.py
+++ b/hotxlfp/grammarparser/parser.py
@@ -124,8 +124,12 @@ class FormulaParser(Parser):
                    | NUMBER DECIMAL
                    | NUMBER DECIMAL NUMBER
                    | NUMBER PERCENT
+                   | DECIMAL NUMBER
         """
-        if len(p) == 2:
+        if p[1] == '.' and len(p) == 3:
+            p2 = p[2]
+            p[0] = lambda args: to_number('.' + p2)
+        elif len(p) == 2:
             p[0] = lambda args, p1=p[1]: to_number(p1)
         elif p[2] == '.':
             if len(p) == 4:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='hotxlfp',
-    version='0.0.11-unc15',
+    version='0.0.11-unc16',
     packages=['hotxlfp', 'hotxlfp._compat', 'hotxlfp._compat.py3', 'hotxlfp.helper', 'hotxlfp.formulas', 'hotxlfp.grammarparser'],
     license='MIT',
     test_suite='tests',

--- a/tests/test_formula_parser.py
+++ b/tests/test_formula_parser.py
@@ -253,6 +253,13 @@ class TestFormulaParser(unittest.TestCase):
         _test_equation(equation="a1 / a1 - a1", variables={"a1": [5]}, answer=[-4])
         _test_equation(equation="-a1 (a1) -a1", variables={"a1": [5]}, answer=[-30])
 
+    def test_decimal(self):
+        _test_equation(equation=".99", variables={"a1": [1]}, answer=[.99])
+        _test_equation(equation="a1/.99", variables={"a1": [1]}, answer=[1 / .99])
+        _test_equation(equation="a1/.99", variables={"a1": [1]}, answer=[1/.99])
+        _test_equation(equation="a1/0.99", variables={"a1": [1]}, answer=[1/.99])
+        _test_equation(equation="a1 + .9+.9", variables={"a1": [1]}, answer=[1 + .9 + .9])
+        _test_equation(equation="a1 + .009/.099*.009 - a1", variables={"a1": [1]}, answer=[1 + .009/.099*.009 - 1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes issue with numbers that started with a zero not being parsed correctly, like `.99` instead of `0.99`