### PR TITLE
Fix order of operations

### DIFF
--- a/hotxlfp/formulas/utils.py
+++ b/hotxlfp/formulas/utils.py
@@ -25,7 +25,7 @@ OPERATOR_DICT = {
     "=": operator.eq,
     ">=": operator.ge,
     "<=": operator.le,
-    "^": lambda a, b: torch.pow(torch.tensor(a), torch.tensor(b)),
+    "^": lambda a, b: torch.float_power(torch.tensor(a), torch.tensor(b)),
 }
 
 REGEX_CRITERIA = re.compile(r'(?P<op>[\<\>\=]*)(?P<val>[\w\d\s\.\*\?]+)', re.UNICODE)

--- a/hotxlfp/grammarparser/parser.py
+++ b/hotxlfp/grammarparser/parser.py
@@ -53,7 +53,7 @@ class Parser(object):
                   tabmodule=self.tabmodule)
 
     def parse(self, input):
-        return yacc.parse(input)
+        return yacc.parse(input)  # add debug=True for testing
 
     def run(self):
         while 1:
@@ -76,9 +76,21 @@ class FormulaParser(Parser):
         """
         expression : expression PLUS expression
                   | expression MINUS expression
+                  | expression_paren MINUS expression_paren
+                  | expression MINUS expression_paren
+                  | expression_paren MINUS expression
+                  | expression_paren MULT expression_paren
                   | expression MULT expression
+                  | expression_paren MULT expression
+                  | expression MULT expression_paren
+                  | expression_paren DIV expression_paren
+                  | expression_paren DIV expression
+                  | expression DIV expression_paren
                   | expression DIV expression
                   | expression AMP expression
+                  | expression_paren CARET expression_paren
+                  | expression_paren CARET expression
+                  | expression CARET expression_paren
                   | expression CARET expression
         """
         if p[2] == '&':

--- a/hotxlfp/grammarparser/parser.py
+++ b/hotxlfp/grammarparser/parser.py
@@ -76,9 +76,6 @@ class FormulaParser(Parser):
         """
         expression : expression PLUS expression
                   | expression MINUS expression
-                  | expression_paren MINUS expression_paren
-                  | expression MINUS expression_paren
-                  | expression_paren MINUS expression
                   | expression MULT expression
                   | expression DIV expression
                   | expression AMP expression

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="hotxlfp",
-    version="0.0.11-unc17",
+    version="0.0.11-unc18",
     packages=[
         "hotxlfp",
         "hotxlfp._compat",

--- a/tests/test_formula_parser.py
+++ b/tests/test_formula_parser.py
@@ -340,9 +340,14 @@ class TestFormulaParser(unittest.TestCase):
         )
 
     def test_order_of_operations(self):
+        _test_equation(equation="2^-2-1", variables={"a1": [1]}, answer=[-.75])
         _test_equation(equation="(2^(-1))", variables={"a1": [1]}, answer=[0.5])
         _test_equation(equation="((2^(-1))-1)", variables={"a1": [1]}, answer=[-0.5])
-        _test_equation(equation="(2^((-1)-1))", variables={"a1": [1]}, answer=[0.25])
+        _test_equation(equation="2^2-1", variables={"a1": [1]}, answer=[3])
+        _test_equation(equation="2^((-1)-1)", variables={"a1": [1]}, answer=[0.25])
+        _test_equation(equation="2/((-1)-1)", variables={"a1": [1]}, answer=[-1])
+        _test_equation(equation="2*((-1)-1)", variables={"a1": [1]}, answer=[-4])
+        _test_equation(equation="2+((-1)-1)", variables={"a1": [1]}, answer=[0])
         _test_equation(equation="(2^1-1)", variables={"a1": [1]}, answer=[1])
         _test_equation(equation="(2^(-1)-1)", variables={"a1": [1]}, answer=[-0.5])
         _test_equation(equation="1 + 2 * 3 - 4", variables={"a1": [1]}, answer=[3])

--- a/tests/test_formula_parser.py
+++ b/tests/test_formula_parser.py
@@ -339,6 +339,14 @@ class TestFormulaParser(unittest.TestCase):
             answer=[1 + 0.009 / 0.099 * 0.009 - 1],
         )
 
+    def test_order_of_operations(self):
+        _test_equation(equation="(2^(-1))", variables={"a1": [1]}, answer=[0.5])
+        _test_equation(equation="((2^(-1))-1)", variables={"a1": [1]}, answer=[-0.5])
+        _test_equation(equation="(2^((-1)-1))", variables={"a1": [1]}, answer=[0.25])
+        _test_equation(equation="(2^1-1)", variables={"a1": [1]}, answer=[1])
+        _test_equation(equation="(2^(-1)-1)", variables={"a1": [1]}, answer=[-0.5])
+        _test_equation(equation="1 + 2 * 3 - 4", variables={"a1": [1]}, answer=[3])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes case like `(2^(-1)-1)`. It was evaluating:
```
expression caret expression_paren minus expression
```
into
```
expression caret expression
```
when it should have evaluated it into:
```
expression minus expression
```