### PR TITLE
Require 3 args for if statements

### DIFF
--- a/hotxlfp/grammarparser/parser.py
+++ b/hotxlfp/grammarparser/parser.py
@@ -170,6 +170,11 @@ class FormulaParser(Parser):
         """
         p[0] = lambda args, p1=p[1], p3=p[3]: self.call_function(p1, p3(args))
 
+    def p_expression_3args(self, p):
+        """
+        expression : FUNCTION_3ARGS LPAREN expression COMMA expression COMMA expression RPAREN
+        """
+        p[0] = lambda args, p1=p[1], p3=p[3], p5=p[5], p7=p[7]: self.call_function(p1, [p3(args), p5(args), p7(args)])
 
     # TODO: This function is not migrated yet
     def p_expression_array(self, p):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="hotxlfp",
-    version="0.0.11-unc20",
+    version="0.0.11-unc21",
     packages=[
         "hotxlfp",
         "hotxlfp._compat",


### PR DESCRIPTION
Requires exactly 3 args for IF statements.

So `IF(a > 10, 5, 6)` should work, but `IF(A ? 10, 5)`, should result in an error