### PR TITLE
Better torch support with tensors

### DIFF
--- a/hotxlfp/formulas/mathtrig.py
+++ b/hotxlfp/formulas/mathtrig.py
@@ -23,7 +23,7 @@ def ABS(number):
     number = utils.parse_number(number)
     if isinstance(number, error.XLError):
         return number
-    return abs(number)
+    return torch.abs(torch.tensor(number))
 
 
 @dispatcher.register_for("ACOS")
@@ -31,7 +31,7 @@ def ACOS(number):
     number = utils.parse_number(number)
     if isinstance(number, error.XLError):
         return number
-    return math.acos(number)
+    return torch.acos(torch.tensor(number))
 
 
 @dispatcher.register_for("ACOSH")
@@ -39,7 +39,7 @@ def ACOSH(number):
     number = utils.parse_number(number)
     if isinstance(number, error.XLError):
         return number
-    return math.log(number + math.sqrt(number * number - 1))
+    return torch.log(torch.tensor(number) + torch.sqrt(torch.tensor(number) * torch.tensor(number) - 1))
 
 
 @dispatcher.register_for("ACOT")
@@ -47,7 +47,7 @@ def ACOT(number):
     number = utils.parse_number(number)
     if isinstance(number, error.XLError):
         return number
-    return math.atan(1 / number)
+    return torch.atan(1 / torch.tensor(number))
 
 
 @dispatcher.register_for("ACOTH")
@@ -55,7 +55,7 @@ def ACOTH(number):
     number = utils.parse_number(number)
     if isinstance(number, error.XLError):
         return number
-    return 0.5 * math.log((number + 1) / (number - 1))
+    return 0.5 * torch.log((torch.tensor(number) + 1) / torch.tensor(number) - 1)
 
 
 @dispatcher.register_for("SIN")
@@ -63,7 +63,7 @@ def SIN(number):
     number = utils.parse_number(number)
     if isinstance(number, error.XLError):
         return number
-    return math.sin(number)
+    return torch.sin(torch.tensor(number))
 
 
 @dispatcher.register_for("SINH")
@@ -71,7 +71,7 @@ def SINH(number):
     number = utils.parse_number(number)
     if isinstance(number, error.XLError):
         return number
-    return math.sinh(number)
+    return torch.sinh(torch.tensor(number))
 
 
 @dispatcher.register_for("ASIN")
@@ -79,7 +79,7 @@ def ASIN(number):
     number = utils.parse_number(number)
     if isinstance(number, error.XLError):
         return number
-    return math.asin(number)
+    return torch.asin(torch.tensor(number))
 
 
 @dispatcher.register_for("ASINH")
@@ -87,7 +87,7 @@ def ASINH(number):
     number = utils.parse_number(number)
     if isinstance(number, error.XLError):
         return number
-    return math.asinh(number)
+    return torch.asinh(torch.tensor(number))
 
 
 @dispatcher.register_for("COS")
@@ -95,7 +95,7 @@ def COS(number):
     number = utils.parse_number(number)
     if isinstance(number, error.XLError):
         return number
-    return math.cos(number)
+    return torch.cos(torch.tensor(number))
 
 
 @dispatcher.register_for("COSH")
@@ -103,7 +103,7 @@ def COSH(number):
     number = utils.parse_number(number)
     if isinstance(number, error.XLError):
         return number
-    return math.cosh(number)
+    return torch.cosh(torch.tensor(number))
 
 
 @dispatcher.register_for("COT")
@@ -111,7 +111,7 @@ def COT(number):
     number = utils.parse_number(number)
     if isinstance(number, error.XLError):
         return number
-    return math.cos(number) / math.sin(number)
+    return torch.cos(torch.tensor(number)) / torch.sin(torch.tensor(number))
 
 
 @dispatcher.register_for("TAN")
@@ -127,7 +127,7 @@ def TANH(number):
     number = utils.parse_number(number)
     if isinstance(number, error.XLError):
         return number
-    return math.tanh(number)
+    return torch.tanh(torch.tensor(number))
 
 
 @dispatcher.register_for("ATAN")
@@ -135,7 +135,7 @@ def ATAN(number):
     number = utils.parse_number(number)
     if isinstance(number, error.XLError):
         return number
-    return math.atan(number)
+    return torch.atan(torch.tensor(number))
 
 
 @dispatcher.register_for("ATAN2")
@@ -146,7 +146,7 @@ def ATAN2(x_num, y_num):
     y_num = utils.parse_number(x_num)
     if isinstance(y_num, error.XLError):
         return y_num
-    return math.atan2(x_num, y_num)
+    return torch.atan2(torch.tensor(x_num), torch.tensor(y_num))
 
 
 @dispatcher.register_for("ATANH")
@@ -154,7 +154,7 @@ def ATANH(number):
     number = utils.parse_number(number)
     if isinstance(number, error.XLError):
         return number
-    return math.atanh(number)
+    return torch.atanh(torch.tensor(number))
 
 
 @dispatcher.register_for("SQRT")
@@ -162,7 +162,7 @@ def SQRT(number):
     number = utils.parse_number(number)
     if isinstance(number, error.XLError):
         return number
-    return math.sqrt(number)
+    return torch.sqrt(torch.tensor(number))
 
 
 @dispatcher.register_for("EXP")
@@ -170,7 +170,7 @@ def EXP(number):
     number = utils.parse_number(number)
     if isinstance(number, error.XLError):
         return number
-    return math.e**number
+    return torch.exp(torch.tensor(number))
 
 
 @dispatcher.register_for("LN")
@@ -200,7 +200,7 @@ def LOG10(number):
 
 @dispatcher.register_for("PI")
 def PI():
-    return math.pi
+    return torch.tensor(math.pi)
 
 
 @dispatcher.register_for("ROUND")

--- a/hotxlfp/grammarparser/parser.py
+++ b/hotxlfp/grammarparser/parser.py
@@ -137,18 +137,18 @@ class FormulaParser(Parser):
         """
         if p[1] == '.' and len(p) == 3:
             p2 = p[2]
-            p[0] = lambda args: to_number('.' + p2)
+            p[0] = lambda args: to_number('.' + p2, args)
         elif len(p) == 2:
-            p[0] = lambda args, p1=p[1]: to_number(p1)
+            p[0] = lambda args, p1=p[1]: to_number(p1, args)
         elif p[2] == '.':
             if len(p) == 4:
-                p[0] = lambda args, p1=p[1], p3=p[3]: to_number(p1 + '.' + p3)
+                p[0] = lambda args, p1=p[1], p3=p[3]: to_number(p1 + '.' + p3, args)
             else:
-                p[0] = lambda args, p1=p[1]: to_number(p1)
+                p[0] = lambda args, p1=p[1]: to_number(p1, args)
         elif p[2] == '^':
-            p[0] = lambda args, p1=p[1], p3=p[3]: to_number(p1)**to_number(p3)
+            p[0] = lambda args, p1=p[1], p3=p[3]: to_number(p1, args)**to_number(p3, args)
         elif p[2] == '%':
-            p[0] = lambda args, p1=p[1]: to_number(p1) * 0.01
+            p[0] = lambda args, p1=p[1]: to_number(p1, args) * 0.01
 
     def p_expression_string(self, p):
         """

--- a/hotxlfp/helper/number.py
+++ b/hotxlfp/helper/number.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import ipdb
 import torch
 
 from .._compat import number_types, string_types

--- a/hotxlfp/helper/number.py
+++ b/hotxlfp/helper/number.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
+import ipdb
+import torch
+
 from .._compat import number_types, string_types
 
-def to_number(number):
+def to_number_wrapper(number):
     if isinstance(number, number_types):
         return number
     if isinstance(number, string_types):
@@ -15,6 +18,15 @@ def to_number(number):
     if isinstance(number, bool):
         return 1 if number else 0
     return number
+
+def to_number(number, args = None):
+    number = to_number_wrapper(number)
+    if args is not None:
+        args_list = list(args.values())
+        if not (isinstance(number, torch.Tensor)) and len(args_list) > 0 and isinstance(args_list[0], torch.Tensor):
+            return torch.ones_like(args_list[0]) * number
+    return number
+
 
 def invert_number(number):
     return -1 * to_number(number)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="hotxlfp",
-    version="0.0.11-unc21",
+    version="0.0.11-unc22",
     packages=[
         "hotxlfp",
         "hotxlfp._compat",

--- a/tests/test_formula_parser.py
+++ b/tests/test_formula_parser.py
@@ -20,6 +20,7 @@ def _test_equation(
     except (error.XLError, TypeError):
         assert should_fail
         return
+    assert isinstance(result, torch.Tensor)
     assert (
         torch.abs(result - torch.tensor(answer)) < 0.000001
     ).all(), f"{result} != {answer}"
@@ -365,6 +366,15 @@ class TestFormulaParser(unittest.TestCase):
         _test_equation(equation="IF(,, )", variables={"a1": [4]}, should_fail=True)
         _test_equation(equation="IF(a1 > 100, 40, IF(a1 > 1, 4, 56))", variables={"a1": [40]}, answer=[4])
         _test_equation(equation="IF(a1 > 10, 40, IF(a1 > 10, 4))", variables={"a1": [4]}, should_fail=True)
+
+    def test_tensors(self):
+        _test_equation(equation="MIN(a1 * 2, 2, 23, a1)", variables={"a1": [5]}, answer=[2])
+        _test_equation(equation="MIN(2, a1 * 2)", variables={"a1": [5]}, answer=[2])
+        _test_equation(equation="MAX(a1 * 2, 2)", variables={"a1": [5]}, answer=[10])
+        _test_equation(equation="MAX(2, a1 * 2)", variables={"a1": [5]}, answer=[10])
+        _test_equation(equation="MAX(MAX(2, a1 * 2), 100)", variables={"a1": [5, 4]}, answer=[100, 100])
+        _test_equation(equation="5", variables={"a1": [5, 4]}, answer=[5])
+        _test_equation(equation="SQRT(100)", variables={"a1": [5]}, answer=[10])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Makes it so that this library will return a tensor in more cases. The two cases it catches here are 
- If you have a constant, like f(x) = 5, and you pass in a tensor, it would previously not return a tensor. Now it should broacast the 5 to the same shape as the tensor that you pass in.

- Previously, if you pass a constant into a function that takes multiple arguments, like `MIN(tensor, 5)`, it would not broadcast the 5 to be a tensor.