### PR TITLE
Change version ID for PEP 440 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 from io import open
+
 from setuptools import setup
 
 setup(
     name="hotxlfp",
-    version="0.0.11-unc22",
+    version="0.0.11+unc.23",
     packages=[
         "hotxlfp",
         "hotxlfp._compat",


### PR DESCRIPTION
See [docs](https://peps.python.org/pep-0440/#local-version-segments) and [eventbrite blog post](https://www.eventbrite.com/engineering/packaging-and-releasing-private-python-code-pt-1/)